### PR TITLE
A couple minor tweaks to the lint to accept more short variables

### DIFF
--- a/{{ cookiecutter.library_name }}/.pylintrc
+++ b/{{ cookiecutter.library_name }}/.pylintrc
@@ -300,7 +300,7 @@ function-rgx=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
 
 # Good variable names which should always be accepted, separated by a comma
 # good-names=i,j,k,ex,Run,_
-good-names=r,g,b,i,j,k,n,ex,Run,_
+good-names=r,g,b,w,i,j,k,n,x,y,z,ex,ok,Run,_
 
 # Include a hint for the correct naming format with invalid-name
 include-naming-hint=no
@@ -422,7 +422,7 @@ max-returns=6
 max-statements=50
 
 # Minimum number of public methods for a class (see R0903).
-min-public-methods=2
+min-public-methods=1
 
 
 [EXCEPTIONS]

--- a/{{ cookiecutter.library_name }}/{% if cookiecutter.library_prefix %}{{ cookiecutter.library_prefix | lower }}_{% endif %}{{ cookiecutter.library_name | lower }}.py
+++ b/{{ cookiecutter.library_name }}/{% if cookiecutter.library_prefix %}{{ cookiecutter.library_prefix | lower }}_{% endif %}{{ cookiecutter.library_name | lower }}.py
@@ -28,5 +28,7 @@ TODO(description)
 * Author(s): {{ cookiecutter.author }}
 """
 
+# imports
+
 __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/{{ cookiecutter.github_user }}/{% if cookiecutter.library_prefix %}{{ cookiecutter.library_prefix | capitalize}}_{% endif %}CircuitPython_{{ cookiecutter.library_name }}.git"


### PR DESCRIPTION
and classes with few public methods (which doesn't count attributes).

Also, add a comment about where imports go relative to __version__.