### PR TITLE
Disable bad-whitespace check on example files.

### DIFF
--- a/{{ cookiecutter.library_name }}/.travis.yml
+++ b/{{ cookiecutter.library_name }}/.travis.yml
@@ -27,5 +27,5 @@ install:
 
 script:
   - pylint {% if cookiecutter.library_prefix %}{{ cookiecutter.library_prefix | lower }}_{% endif %}{{ cookiecutter.library_name | lower }}.py
-  - ([[ ! -d "examples" ]] || pylint --disable=missing-docstring,invalid-name examples/*.py)
+  - ([[ ! -d "examples" ]] || pylint --disable=missing-docstring,invalid-name,bad-whitespace examples/*.py)
   - circuitpython-build-bundles --filename_prefix {% if cookiecutter.library_prefix %}{{ cookiecutter.library_prefix | lower }}-{% endif %}circuitpython-{{ cookiecutter.library_name | lower }} --library_location .


### PR DESCRIPTION
This is a change to add bad-whitespace as a disabled check for pylint's verification of files in the examples folder.  This goes along with the existing invalid-name disable and prevents pylint from failing builds erroneously when examples use explicit vertical alignment of whitespace (for example pin number lists are easier to read with vertical alignment: https://github.com/adafruit/Adafruit_CircuitPython_RFM69/blob/master/examples/simpletest.py#L16-L18 ).  Like with the invalid-name and missing-docstring checks rather than complicate the examples with pylint disable comments it's better to disable this check globally for the examples (but not the library code).