### PR TITLE
Enable napoleon

### DIFF
--- a/{{ cookiecutter.library_name }}/docs/conf.py
+++ b/{{ cookiecutter.library_name }}/docs/conf.py
@@ -12,6 +12,7 @@ sys.path.insert(0, os.path.abspath('..'))
 extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.intersphinx',
+    'sphinx.ext.napoleon'
     'sphinx.ext.todo',
 ]
 
@@ -81,6 +82,7 @@ todo_include_todos = False
 # If this is True, todo emits a warning for each TODO entries. The default is False.
 todo_emit_warnings = True
 
+napoleon_numpy_docstring = False
 
 # -- Options for HTML output ----------------------------------------------
 


### PR DESCRIPTION
This enables Google Style docstrings which are more readable than RST. http://www.sphinx-doc.org/en/stable/ext/napoleon.html#module-sphinx.ext.napoleon

RST style docstrings will still work though.