### PR TITLE
Make bundle location absolute

### DIFF
--- a/{{ cookiecutter.library_name }}/.travis.yml
+++ b/{{ cookiecutter.library_name }}/.travis.yml
@@ -16,7 +16,7 @@ deploy:
   provider: releases
   api_key: $GITHUB_TOKEN
   file_glob: true
-  file: bundles/*
+  file: $TRAVIS_BUILD_DIR/bundles/*
   skip_cleanup: true
   overwrite: true
   on:


### PR DESCRIPTION
Having it relative meant that changing directory in the script section messes it up. This way, it doesn't matter what the script section does.