### PR TITLE
Added Pylint & RPi/Blinka Updates

### DIFF
--- a/{{ cookiecutter.library_name }}/.pylintrc
+++ b/{{ cookiecutter.library_name }}/.pylintrc
@@ -156,7 +156,7 @@ ignored-classes=optparse.Values,thread._local,_thread._local
 # (useful for modules/projects where namespaces are manipulated during runtime
 # and thus existing member attributes cannot be deduced by static analysis. It
 # supports qualified module names, as well as Unix pattern matching.
-ignored-modules=
+ignored-modules=board
 
 # Show a hint with possible names when a member name was not found. The aspect
 # of finding the hint is based on edit distance.

--- a/{{ cookiecutter.library_name }}/.travis.yml
+++ b/{{ cookiecutter.library_name }}/.travis.yml
@@ -23,7 +23,8 @@ deploy:
     tags: true
 
 install:
-  - pip install pylint circuitpython-build-tools Sphinx sphinx-rtd-theme
+  - pip install circuitpython-build-tools Sphinx sphinx-rtd-theme
+  - pip install --force-reinstall pylint==1.9.2
 
 script:
   - pylint {% if cookiecutter.library_prefix %}{{ cookiecutter.library_prefix | lower }}_{% endif %}{{ cookiecutter.library_name | lower }}.py


### PR DESCRIPTION
- updated `.travis.yml` to force-install pylint v1.9.2

- added `board` to `.pylintrc->ignore-modules` to avoid errors when using with RPi/Blinka.