### PR TITLE
Fix README.rst {{ library_prefix }} Capitalization

### DIFF
--- a/{{ cookiecutter.library_name }}/README.rst
+++ b/{{ cookiecutter.library_name }}/README.rst
@@ -1,5 +1,5 @@
 {% if cookiecutter.library_prefix -%}
-    {% set prefix = cookiecutter.library_prefix + "_" -%}
+    {% set prefix = cookiecutter.library_prefix | capitalize + "_" -%}
 {% else -%}
     {% set prefix = '' -%}
 {% endif -%}


### PR DESCRIPTION
Fixes #33.

Tested (result highlighted below) with both `library_prefix = adafruit` and `library_prefix = Adafruit`.

![cookiecutter_readme_libprefix_cap](https://user-images.githubusercontent.com/21211479/46839591-3bf3a300-cd84-11e8-9143-53c72f3e0dc0.png)
