### PR TITLE
Remove diff Output In requirements.txt

### DIFF
--- a/{{ cookiecutter.library_name }}/requirements.txt
+++ b/{{ cookiecutter.library_name }}/requirements.txt
@@ -1,9 +1,5 @@
-<<<<<<< HEAD
-{% if cookiecutter.depends_on_bus_device in ["y", "yes"] -%}
-=======
 Adafruit-Blinka
-{% if cookiecutter.depends_on_bus_device != "" -%}
->>>>>>> 1396aa5e662000d07f390d746a9e28905099bfa1
+{% if cookiecutter.depends_on_bus_device in ["y", "yes"] -%}
 adafruit-circuitpython-busdevice
 {%- endif %}
 {%- if cookiecutter.depends_on_register in ["y", "yes"] %}


### PR DESCRIPTION
Somehow the diff output from a merge got in. I remember handling the diff before the last PR, but it must have been a dream. Thanks @caternuson for pointing this out!