### PR TITLE
Update README Travis Badge

### DIFF
--- a/{{ cookiecutter.library_name }}/README.rst
+++ b/{{ cookiecutter.library_name }}/README.rst
@@ -20,8 +20,8 @@ Introduction
     :target: https://discord.gg/nBQh6qu
     :alt: Discord
 
-.. image:: https://travis-ci.org/{{ full_repo_name }}.svg?branch=master
-    :target: https://travis-ci.org/{{ full_repo_name }}
+.. image:: https://travis-ci.com/{{ full_repo_name }}.svg?branch=master
+    :target: https://travis-ci.com/{{ full_repo_name }}
     :alt: Build Status
 
 .. todo:: Describe what the library does.


### PR DESCRIPTION
This updates the Travis badges in the README for the switch to `travis-ci.com`.