### PR TITLE
PyPi Updates

### DIFF
--- a/{{ cookiecutter.library_name }}/README.rst
+++ b/{{ cookiecutter.library_name }}/README.rst
@@ -46,6 +46,34 @@ Please ensure all dependencies are available on the CircuitPython filesystem.
 This is easily achieved by downloading
 `the Adafruit library and driver bundle <https://github.com/adafruit/Adafruit_CircuitPython_Bundle>`_.
 
+Installing from PyPI
+--------------------
+.. note:: This library is not available on PyPI yet. Install documentation is included
+   as a standard element. Stay tuned for PyPI availability!
+.. todo:: Remove the above note if PyPI version is/will be available at time of release.
+   If the library is not planned for PyPI, remove the entire 'Installing from PyPI' section.
+On supported GNU/Linux systems like the Raspberry Pi, you can install the driver locally `from
+PyPI <https://pypi.org/project/adafruit-circuitpython-{{ cookiecutter.library_name|lower }}/>`_. To install for current user:
+
+.. code-block:: shell
+
+    pip3 install adafruit-circuitpython-{{ cookiecutter.library_name|lower }}
+
+To install system-wide (this may be required in some cases):
+
+.. code-block:: shell
+
+    sudo pip3 install adafruit-circuitpython-{{ cookiecutter.library_name|lower }}
+
+To install in a virtual environment in your current project:
+
+.. code-block:: shell
+
+    mkdir project-name && cd project-name
+    python3 -m venv .env
+    source .env/bin/activate
+    pip3 install adafruit-circuitpython-{{ cookiecutter.library_name|lower }}
+
 Usage Example
 =============
 

--- a/{{ cookiecutter.library_name }}/setup.py
+++ b/{{ cookiecutter.library_name }}/setup.py
@@ -50,7 +50,8 @@ setup(
     author='Adafruit Industries',
     author_email='circuitpython@adafruit.com',
 
-    install_requires=['{{ req_list.items|unique|join("',\n'")|indent(width=22) }}'
+    install_requires=[
+        '{{ req_list.items|unique|join("',\n'")|indent(width=8) }}'
     ],
 
     # Choose your license


### PR DESCRIPTION
Fixes a PEP8 fail, that pylint complained about. 

More importantly, adds the `Installing from PyPI` section to the library README. On the initial template, the section will contain an rST [note](http://docutils.sourceforge.net/docs/ref/rst/directives.html#note) stating that the library is not available on PyPI. There is also a `todo` to either:
1. Remove the note if the library will be available from PyPI upon release.
2. Remove the entire section if the library will not be released on PyPI.

The `todo` will fail Travis on the sphinx build, so this will be addressed on PRs if missed.
