### PR TITLE
Fixed community moderators on actual cutter

### DIFF
--- a/{{ cookiecutter.library_name }}/CODE_OF_CONDUCT.md
+++ b/{{ cookiecutter.library_name }}/CODE_OF_CONDUCT.md
@@ -41,7 +41,7 @@ Examples of unacceptable behavior by participants include:
 
 The goal of the standards and moderation guidelines outlined here is to build
 and maintain a respectful community. We ask that you don’t just aim to be
-"technically unimpeachable", but rather try to be your best self. 
+"technically unimpeachable", but rather try to be your best self.
 
 We value many things beyond technical expertise, including collaboration and
 supporting others within our community. Providing a positive experience for
@@ -72,7 +72,7 @@ You may report in the following ways:
 In any situation, you may send an email to <support@adafruit.com>.
 
 On the Adafruit Discord, you may send an open message from any channel
-to all Community Helpers by tagging @community helpers. You may also send an
+to all Community Helpers by tagging @community moderators. You may also send an
 open message from any channel, or a direct message to @kattni#1507,
 @tannewt#4653, @Dan Halbert#1614, @cater#2442, @sommersoft#0222, or
 @Andon#8175.


### PR DESCRIPTION
I had previously changed community helpers to moderators, but it was on the Code of Conduct for the cutter instead of the cutter content itself.