### PR TITLE
removing confusing an not useful local build instructions

### DIFF
--- a/{{ cookiecutter.library_name }}/README.rst
+++ b/{{ cookiecutter.library_name }}/README.rst
@@ -89,33 +89,6 @@ Contributions are welcome! Please read our `Code of Conduct
 <https://github.com/{{ full_repo_name }}/blob/master/CODE_OF_CONDUCT.md>`_
 before contributing to help this project stay welcoming.
 
-Building locally
-================
-
-Zip release files
------------------
-
-To build this library locally you'll need to install the
-`circuitpython-build-tools <https://github.com/adafruit/circuitpython-build-tools>`_ package.
-
-.. code-block:: shell
-
-    python3 -m venv .env
-    source .env/bin/activate
-    pip install circuitpython-build-tools
-
-Once installed, make sure you are in the virtual environment:
-
-.. code-block:: shell
-
-    source .env/bin/activate
-
-Then run the build:
-
-.. code-block:: shell
-
-    circuitpython-build-bundles --filename_prefix {% if cookiecutter.library_prefix %}{{ cookiecutter.library_prefix | lower }}-{% endif %}circuitpython-{{ cookiecutter.library_name | lower }} --library_location .
-
 Sphinx documentation
 -----------------------
 


### PR DESCRIPTION
Removing this section was discussed between @ladyada and @tannewt, and I agree that it is more confusing than helpful.