### PR TITLE
to point to circuitpython.org for the bundle

### DIFF
--- a/{{ cookiecutter.library_name }}/README.rst
+++ b/{{ cookiecutter.library_name }}/README.rst
@@ -45,7 +45,7 @@ This driver depends on:
 
 Please ensure all dependencies are available on the CircuitPython filesystem.
 This is easily achieved by downloading
-`the Adafruit library and driver bundle <https://github.com/adafruit/Adafruit_CircuitPython_Bundle>`_.
+`the Adafruit library and driver bundle <https://circuitpython.org/libraries>`_.
 
 Installing from PyPI
 =====================


### PR DESCRIPTION
A small tweak to point users to circuitpython.org for the bundle instead of the bundle's github repo