### PR TITLE
Copy GitHub Actions Workflows Without Parsing Them

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -9,5 +9,6 @@
     "requires_bus_device": "",
     "requires_register": "",
     "other_requirements": "",
-    "_extensions": ["jinja2.ext.do"]
+    "_extensions": ["jinja2.ext.do"],
+    "_copy_without_render": ["*.github/*"]
 }


### PR DESCRIPTION
In Discord, `wallarug` reported the following cookiecutter error:

![wallarug_cookie_failure](https://user-images.githubusercontent.com/21211479/71751162-4cd47c80-2e40-11ea-9126-a9b6b7377161.png)

The `toJson` is an expression inside the GitHub Actions workflow, used as such: `${{ toJson(blah) }}`.

The Jinja2 parser is reading the `{{ }}` as a Jinja template expression, and obviously failing to execute it.

This fixes this by copying the workflow files in `.github/` without sending them through the Jinja2 parser. I tested this locally, got no errors, and everything was rendered properly.

Uses: [`_copy_without_render`](https://cookiecutter.readthedocs.io/en/latest/advanced/copy_without_render.html).

_I really should've spotted this during the Actions PR review. I may have assumed that the `$` would keep Jinja from trying to parse it._ 🤷‍♂