### PR TITLE
Move Pip Installs Back To Library build.yml

### DIFF
--- a/{{ cookiecutter.library_name }}/.github/workflows/build.yml
+++ b/{{ cookiecutter.library_name }}/.github/workflows/build.yml
@@ -34,9 +34,13 @@ jobs:
       with:
         repository: adafruit/actions-ci-circuitpython-libs
         path: actions-ci
-    - name: Install deps
+    - name: Install dependencies
+      # (e.g. - apt-get: gettext, etc; pip: circuitpython-build-tools, requirements.txt; etc.)
       run: |
         source actions-ci/install.sh
+    - name: Pip install pylint, black, & Sphinx
+      run: |
+        pip install --force-reinstall pylint==1.9.2 black==19.10b0 Sphinx sphinx-rtd-theme
     - name: Library version
       run: git describe --dirty --always --tags
     - name: PyLint

--- a/{{ cookiecutter.library_name }}/README.rst
+++ b/{{ cookiecutter.library_name }}/README.rst
@@ -25,6 +25,10 @@ Introduction
     :target: https://github.com/{{ full_repo_name }}/actions
     :alt: Build Status
 
+.. image:: https://img.shields.io/badge/code%20style-black-000000.svg
+    :target: https://github.com/psf/black
+    :alt: Code Style: Black
+
 {% if cookiecutter.library_description != "" %}
     {{- cookiecutter.library_description }}
 {% else %}


### PR DESCRIPTION
Step 2 of https://github.com/adafruit/actions-ci-circuitpython-libs/issues/2#issuecomment-594226241

I also threw in the ![code style: black](https://img.shields.io/badge/code%20style-black-000000.svg) badge for the README.