### PR TITLE
Don't Pin Pylint Install to 1.9.2

### DIFF
--- a/{{ cookiecutter.library_name }}/.github/workflows/build.yml
+++ b/{{ cookiecutter.library_name }}/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
         source actions-ci/install.sh
     - name: Pip install pylint, black, & Sphinx
       run: |
-        pip install --force-reinstall pylint==1.9.2 black==19.10b0 Sphinx sphinx-rtd-theme
+        pip install --force-reinstall pylint black==19.10b0 Sphinx sphinx-rtd-theme
     - name: Library version
       run: git describe --dirty --always --tags
     - name: PyLint


### PR DESCRIPTION
Was looking over something else during patch follow-ups, and noticed that I erroneously pinned the pylint intstall to `1.9.2`. This should definitely not be the case for a new library.