### PR TITLE
fix my discord username

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -74,7 +74,7 @@ In any situation, you may send an email to <support@adafruit.com>.
 On the Adafruit Discord, you may send an open message from any channel
 to all Community Helpers by tagging @community moderators. You may also send an
 open message from any channel, or a direct message to @kattni#1507,
-@tannewt#4653, @Dan Halbert#1614, @cater#2442, @sommersoft#0222, or
+@tannewt#4653, @danh#1614, @cater#2442, @sommersoft#0222, or
 @Andon#8175.
 
 Email and direct message reports will be kept confidential.


### PR DESCRIPTION
I had changed my username a while ago without being aware it was in the code of conduct.

Does it make sense to have usernames here? The list will become obsolete sooner or later. Maybe just point to the group name.