### PR TITLE
Added a step that renders the readme

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,9 +31,3 @@ jobs:
     - name: Run cookiecutter tests
       run: |
         pytest -v
-    - name: Test README
-      run: |
-        pip install --user --upgrade setuptools wheel twine readme_renderer testresources
-        python setup.py sdist
-        python setup.py bdist_wheel --universal
-        twine check dist/*

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,3 +31,9 @@ jobs:
     - name: Run cookiecutter tests
       run: |
         pytest -v
+    - name: Test README
+      run: |
+        pip install --user --upgrade setuptools wheel twine readme_renderer testresources
+        python setup.py sdist
+        python setup.py bdist_wheel --universal
+        twine check dist/*

--- a/{{ cookiecutter.library_name }}/.github/workflows/build.yml
+++ b/{{ cookiecutter.library_name }}/.github/workflows/build.yml
@@ -59,7 +59,7 @@ jobs:
     - name: Build docs
       working-directory: docs
       run: sphinx-build -E -W -b html . _build/html
-    - name: Build README
+    - name: Build Python package
       run: |
         pip install --upgrade setuptools wheel twine readme_renderer testresources
         python setup.py sdist

--- a/{{ cookiecutter.library_name }}/.github/workflows/build.yml
+++ b/{{ cookiecutter.library_name }}/.github/workflows/build.yml
@@ -61,7 +61,7 @@ jobs:
       run: sphinx-build -E -W -b html . _build/html
     - name: Build README
       run: |
-        pip install --user --upgrade setuptools wheel twine readme_renderer testresources
+        pip install --upgrade setuptools wheel twine readme_renderer testresources
         python setup.py sdist
         python setup.py bdist_wheel --universal
         twine check dist/*

--- a/{{ cookiecutter.library_name }}/.github/workflows/build.yml
+++ b/{{ cookiecutter.library_name }}/.github/workflows/build.yml
@@ -59,3 +59,9 @@ jobs:
     - name: Build docs
       working-directory: docs
       run: sphinx-build -E -W -b html . _build/html
+    - name: Build README
+      run: |
+        pip install --user --upgrade setuptools wheel twine readme_renderer testresources
+        python setup.py sdist
+        python setup.py bdist_wheel --universal
+        twine check dist/*


### PR DESCRIPTION
#61 

The current issue is that the only time you'll know the README isn't rendering now is after the library has been released to PyPI, which isn't really ideal, since if it isn't rendering right, it doesn't really tell you where the issue is and you'll have to re-release it.