### PR TITLE
Now checks for setup.py

### DIFF
--- a/{{ cookiecutter.library_name }}/.github/workflows/build.yml
+++ b/{{ cookiecutter.library_name }}/.github/workflows/build.yml
@@ -59,7 +59,12 @@ jobs:
     - name: Build docs
       working-directory: docs
       run: sphinx-build -E -W -b html . _build/html
+    - name: Check For setup.py
+      id: need-pypi
+      run: |
+        echo ::set-output name=setup-py::$( find . -wholename './setup.py' )
     - name: Build Python package
+      if: contains(steps.need-pypi.outputs.setup-py, 'setup.py')
       run: |
         pip install --upgrade setuptools wheel twine readme_renderer testresources
         python setup.py sdist


### PR DESCRIPTION
I personally would have preferred to do it in one step, but I wasn't quite sure of the syntax for that and didn't want to spend very long on this. Also, since I stole this from release.yml, I'm a lot more confident in its reliability since it has been used a lot with no issues.

Setup.py.disabled:
https://github.com/adafruit/Adafruit_CircuitPython_TestRepo/runs/914877305?check_suite_focus=true

Setup.py:
https://github.com/adafruit/Adafruit_CircuitPython_ImageLoad/runs/914952033?check_suite_focus=true

@makermelissa Thanks for noticing this