### PR TITLE
Fix Contributor Covenant link in CODE_OF_CONDUCT

### DIFF
--- a/{{ cookiecutter.library_name }}/CODE_OF_CONDUCT.md
+++ b/{{ cookiecutter.library_name }}/CODE_OF_CONDUCT.md
@@ -123,7 +123,7 @@ accordingly.
 
 ## Attribution
 
-This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+This Code of Conduct is adapted from the [Contributor Covenant],
 version 1.4, available at
 <https://www.contributor-covenant.org/version/1/4/code-of-conduct.html>,
 and the [Rust Code of Conduct](https://www.rust-lang.org/en-US/conduct.html).
@@ -133,3 +133,5 @@ Conduct, please contact the maintainers of those projects for enforcement.
 If you wish to use this code of conduct for your own project, consider
 explicitly mentioning your moderation policy or making a copy with your
 own moderation policy so as to avoid confusion.
+
+[Contributor Covenant]: https://www.contributor-covenant.org


### PR DESCRIPTION
`[Contributor Covenant][homepage]` towards the bottom of the document didn't have a matching `[homepage]: https://...` link definition in the Markdown document, so "Contributor Covenant" was a broken link until now