### PR TITLE
autoclass_content = both

### DIFF
--- a/{{ cookiecutter.library_name }}/docs/conf.py
+++ b/{{ cookiecutter.library_name }}/docs/conf.py
@@ -39,6 +39,9 @@ intersphinx_mapping = {
     "CircuitPython": ("https://circuitpython.readthedocs.io/en/latest/", None),
 }
 
+# Show the docstring from both the class and its __init__() method.
+autoclass_content = "both"
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
 


### PR DESCRIPTION
Fixes #86. Adds `autoclass_content = both` to `docs/conf.py` in the template.

