### PR TITLE
archive built assets as artifacts in build.yml workflow

### DIFF
--- a/{{ cookiecutter.library_name }}/.github/workflows/build.yml
+++ b/{{ cookiecutter.library_name }}/.github/workflows/build.yml
@@ -56,6 +56,11 @@ jobs:
         ([[ ! -d "examples" ]] || pylint --disable=missing-docstring,invalid-name,bad-whitespace $( find . -path "./examples/*.py" ))
     - name: Build assets
       run: circuitpython-build-bundles --filename_prefix ${{ steps.repo-name.outputs.repo-name }} --library_location .
+    - name: Archive bundles
+      uses: actions/upload-artifact@v2
+      with:
+        name: bundles
+        path: ${{ github.workspace }}/bundles/
     - name: Build docs
       working-directory: docs
       run: sphinx-build -E -W -b html . _build/html


### PR DESCRIPTION
This adds a simple step to the build.yml workflow that allows downloading the built assets for a specific job run (if successful). Addresses #92 and should be useful for inspecting/testing assets before release, especially if mpy files are needed when developing and your local machine isn't equipped to build the assets.

According to the github action docs:
>By default, GitHub stores build logs and artifacts for 90 days, and this retention period can be customized. For more information, see "[Usage limits, billing, and administration](https://docs.github.com/en/free-pro-team@latest/actions/reference/usage-limits-billing-and-administration#artifact-and-log-retention-policy)". The retention period for a pull request restarts each time someone pushes a new commit to the pull request.

See also the README in the [actions/upload-artifacts](https://github.com/actions/upload-artifact#retention-period) about adjusting retention period (defaults to max 90 days).
