### PR TITLE
Add Black formatting check.

### DIFF
--- a/{{ cookiecutter.library_name }}/.github/workflows/build.yml
+++ b/{{ cookiecutter.library_name }}/.github/workflows/build.yml
@@ -42,14 +42,17 @@ jobs:
       # (e.g. - apt-get: gettext, etc; pip: circuitpython-build-tools, requirements.txt; etc.)
       run: |
         source actions-ci/install.sh
-    - name: Pip install pylint, Sphinx, pre-commit
+    - name: Pip install Pylint, Black, Sphinx, pre-commit
       run: |
-        pip install --force-reinstall pylint Sphinx sphinx-rtd-theme pre-commit
+        pip install --force-reinstall pylint black Sphinx sphinx-rtd-theme pre-commit
     - name: Library version
       run: git describe --dirty --always --tags
     - name: Pre-commit hooks
       run: |
         pre-commit run --all-files
+    - name: Check formatting
+      run: |
+        black --check --target-version=py35 .
     - name: PyLint
       run: |
         pylint $( find . -path './adafruit*.py' )


### PR DESCRIPTION
This was not added to `cookiecutter` when we added it to the libraries. We need to update the libraries currently using black to using the latest version (it's causing issues with folks running it locally when they install it as we suggested), and we also need to add it to all the libraries created since we initially added Black to the libraries as none of them have it because it wasn't added to `cookiecutter`. These are separate from this PR and will be done using Adabot.