### PR TITLE
Pre-Commit requires specific versions be used

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@
 
 repos:
 -   repo: https://github.com/fsfe/reuse-tool
-    rev: latest
+    rev: v0.12.1
     hooks:
     - id: reuse
 -   repo: https://github.com/pre-commit/pre-commit-hooks

--- a/{{ cookiecutter.library_name }}/.pre-commit-config.yaml
+++ b/{{ cookiecutter.library_name }}/.pre-commit-config.yaml
@@ -4,11 +4,11 @@
 
 repos:
 -   repo: https://github.com/python/black
-    rev: stable
+    rev: 20.8b1
     hooks:
     - id: black
 -   repo: https://github.com/fsfe/reuse-tool
-    rev: latest
+    rev: v0.12.1
     hooks:
     - id: reuse
 -   repo: https://github.com/pre-commit/pre-commit-hooks


### PR DESCRIPTION
Fixes #99

Pre-Commit requires specific versions be used. I used the latest for re-use and black as of today.