### PR TITLE
pre-commit: run on all branches & on ubuntu-20.04

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -7,11 +7,10 @@ name: pre-commit
 on:
   pull_request:
   push:
-    branches: [master]
 
 jobs:
   pre-commit:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v1
     - uses: actions/setup-python@v1


### PR DESCRIPTION
I noticed that pre-commit only runs on the 'master' branch.  This will be incorrect if cookiecutter is ever updated to use the 'main' branch designation for primary development.

I also updated the ubuntu version from ubuntu-latest to ubuntu-20.04.  This silences a warning shown in the Actions results pages that the meaning of ubuntu-latest can & will change.