### PR TITLE
Remove pylint process from github workflow

### DIFF
--- a/{% if cookiecutter.library_prefix %}{{ cookiecutter.library_prefix | capitalize }}_{% endif %}CircuitPython_{{ cookiecutter.library_name}}/.github/workflows/build.yml
+++ b/{% if cookiecutter.library_prefix %}{{ cookiecutter.library_prefix | capitalize }}_{% endif %}CircuitPython_{{ cookiecutter.library_name}}/.github/workflows/build.yml
@@ -50,10 +50,6 @@ jobs:
     - name: Pre-commit hooks
       run: |
         pre-commit run --all-files
-    - name: PyLint
-      run: |
-        pylint --ignore=setup.py,conf.py $( find . -path './*.py' )
-        ([[ ! -d "examples" ]] || pylint --disable=missing-docstring,invalid-name,bad-whitespace $( find . -path "./examples/*.py" ))
     - name: Build assets
       run: circuitpython-build-bundles --filename_prefix ${{ steps.repo-name.outputs.repo-name }} --library_location .
     - name: Archive bundles

--- a/{% if cookiecutter.library_prefix %}{{ cookiecutter.library_prefix | capitalize }}_{% endif %}CircuitPython_{{ cookiecutter.library_name}}/.pre-commit-config.yaml
+++ b/{% if cookiecutter.library_prefix %}{{ cookiecutter.library_prefix | capitalize }}_{% endif %}CircuitPython_{{ cookiecutter.library_name}}/.pre-commit-config.yaml
@@ -17,3 +17,17 @@ repos:
     -   id: check-yaml
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
+-   repo: local
+    hooks:
+    -   id: "pylint-library"
+        name: "pylint-library"
+        description: Run pylint rules on library python code files
+        entry: /usr/bin/env bash -c
+        args: ['pylint $( find . -path "./adafruit*.py" )']
+        language: system
+    -   id: pylint_examples
+        name: pylint-examples
+        description: Run pylint rules on "examples/*.py" files
+        entry: /usr/bin/env bash -c
+        args: ['([[ ! -d "examples" ]] || for example in $(find . -path "./examples/*.py"); do pylint --disable=missing-docstring,invalid-name,bad-whitespace $example; done)']
+        language: system

--- a/{% if cookiecutter.library_prefix %}{{ cookiecutter.library_prefix | capitalize }}_{% endif %}CircuitPython_{{ cookiecutter.library_name}}/.pre-commit-config.yaml
+++ b/{% if cookiecutter.library_prefix %}{{ cookiecutter.library_prefix | capitalize }}_{% endif %}CircuitPython_{{ cookiecutter.library_name}}/.pre-commit-config.yaml
@@ -30,5 +30,5 @@ repos:
         name: pylint (examples code)
         description: Run pylint rules on "examples/*.py" files
         entry: /usr/bin/env bash -c
-        args: ['([[ ! -d "examples" ]] || for example in $(find . -path "./examples/*.py"); do pylint --disable=missing-docstring,invalid-name,bad-whitespace $example; done)']
+        args: ['([[ ! -d "examples" ]] || for example in $(find . -path "./examples/*.py"); do pylint --disable=missing-docstring,invalid-name $example; done)']
         language: system

--- a/{% if cookiecutter.library_prefix %}{{ cookiecutter.library_prefix | capitalize }}_{% endif %}CircuitPython_{{ cookiecutter.library_name}}/.pre-commit-config.yaml
+++ b/{% if cookiecutter.library_prefix %}{{ cookiecutter.library_prefix | capitalize }}_{% endif %}CircuitPython_{{ cookiecutter.library_name}}/.pre-commit-config.yaml
@@ -17,14 +17,15 @@ repos:
     -   id: check-yaml
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
+-   repo: https://github.com/pycqa/pylint
+    rev: pylint-2.7.1
+    hooks:
+    -   id: pylint
+        name: pylint (library code)
+        types: [python]
+        exclude: "^(docs/|examples/|setup.py$)"
 -   repo: local
     hooks:
-    -   id: "pylint-library"
-        name: "pylint-library"
-        description: Run pylint rules on library python code files
-        entry: /usr/bin/env bash -c
-        args: ['pylint $( find . -path "./adafruit*.py" )']
-        language: system
     -   id: pylint_examples
         name: pylint-examples
         description: Run pylint rules on "examples/*.py" files

--- a/{% if cookiecutter.library_prefix %}{{ cookiecutter.library_prefix | capitalize }}_{% endif %}CircuitPython_{{ cookiecutter.library_name}}/.pre-commit-config.yaml
+++ b/{% if cookiecutter.library_prefix %}{{ cookiecutter.library_prefix | capitalize }}_{% endif %}CircuitPython_{{ cookiecutter.library_name}}/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
 -   repo: local
     hooks:
     -   id: pylint_examples
-        name: pylint-examples
+        name: pylint (examples code)
         description: Run pylint rules on "examples/*.py" files
         entry: /usr/bin/env bash -c
         args: ['([[ ! -d "examples" ]] || for example in $(find . -path "./examples/*.py"); do pylint --disable=missing-docstring,invalid-name,bad-whitespace $example; done)']


### PR DESCRIPTION
This pull-request addresses issue #104, by moving the pylint process from being part of the GitHub workflow (from `.github/workflows/build.yml`) to being part of the pre-commit workflow, so that it can be run on individual contributors' computers.