### PR TITLE
fix the whitespace removal on RTD badge

### DIFF
--- a/{% if cookiecutter.library_prefix %}{{ cookiecutter.library_prefix | capitalize }}_{% endif %}CircuitPython_{{ cookiecutter.library_name}}/README.rst
+++ b/{% if cookiecutter.library_prefix %}{{ cookiecutter.library_prefix | capitalize }}_{% endif %}CircuitPython_{{ cookiecutter.library_name}}/README.rst
@@ -9,13 +9,15 @@
 Introduction
 ============
 
+{% if cookiecutter.sphinx_docs | lower in ["yes", "y"] %}
 .. image:: https://readthedocs.org/projects/{% if cookiecutter.library_prefix %}{{ cookiecutter.library_prefix | lower | replace("_", "-")}}-{% endif %}circuitpython-{{ cookiecutter.library_name | lower }}/badge/?version=latest
-{%- if cookiecutter.target_bundle == 'Adafruit' -%}
+{%- if cookiecutter.target_bundle == 'Adafruit' %}
     :target: https://circuitpython.readthedocs.io/projects/{{ cookiecutter.library_name | lower }}/en/latest/
 {%- else %}
     :target: https://circuitpython-{{ cookiecutter.library_name | lower }}.readthedocs.io/
 {%- endif %}
     :alt: Documentation Status
+{% endif %}
 
 .. image:: https://img.shields.io/discord/327254708534116352.svg
     :target: https://adafru.it/discord


### PR DESCRIPTION
Thanks @makermelissa  for reporting this
https://github.com/adafruit/Adafruit_CircuitPython_SSD1681/pull/3

Those `{%-` and `%}` to trim whitespace are confusing. ;-)

I also notice that the RTD Badge would have been included if docs was "no" and fixed that as well.