### PR TITLE
Update pylint rules for `./tests/` directory files

### DIFF
--- a/{% if cookiecutter.library_prefix %}{{ cookiecutter.library_prefix | capitalize }}_{% endif %}CircuitPython_{{ cookiecutter.library_name}}/.pre-commit-config.yaml
+++ b/{% if cookiecutter.library_prefix %}{{ cookiecutter.library_prefix | capitalize }}_{% endif %}CircuitPython_{{ cookiecutter.library_name}}/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
     -   id: pylint
         name: pylint (library code)
         types: [python]
-        exclude: "^(docs/|examples/|setup.py$)"
+        exclude: "^(docs/|examples/|tests/|setup.py$)"
 -   repo: local
     hooks:
     -   id: pylint_examples
@@ -31,4 +31,10 @@ repos:
         description: Run pylint rules on "examples/*.py" files
         entry: /usr/bin/env bash -c
         args: ['([[ ! -d "examples" ]] || for example in $(find . -path "./examples/*.py"); do pylint --disable=missing-docstring,invalid-name $example; done)']
+        language: system
+    -   id: pylint_tests
+        name: pylint (tests code)
+        description: Run pylint rules on "tests/*.py" files
+        entry: /usr/bin/env bash -c
+        args: ['([[ ! -d "tests" ]] || for test in $(find . -path "./tests/*.py"); do pylint --disable=missing-docstring $test; done)']
         language: system


### PR DESCRIPTION
Add the './tests' directory as an exception to the general pylint hook
Run a separate set of linting rules for the `./tests` directory, omitting only the `missing-docstring` as a rule to check.

This PR addresses issue #113.