### PR TITLE
Hook in help comment and problem matchers

### DIFF
--- a/{% if cookiecutter.library_prefix %}{{ cookiecutter.library_prefix | capitalize }}_{% endif %}CircuitPython_{{ cookiecutter.library_name}}/.github/workflows/build.yml
+++ b/{% if cookiecutter.library_prefix %}{{ cookiecutter.library_prefix | capitalize }}_{% endif %}CircuitPython_{{ cookiecutter.library_name}}/.github/workflows/build.yml
@@ -47,6 +47,8 @@ jobs:
         pip install --force-reinstall pylint Sphinx sphinx-rtd-theme pre-commit
     - name: Library version
       run: git describe --dirty --always --tags
+    - name: Setup problem matchers
+      uses: adafruit/circuitpython-action-library-ci-problem-matchers@v1
     - name: Pre-commit hooks
       run: |
         pre-commit run --all-files

--- a/{% if cookiecutter.library_prefix %}{{ cookiecutter.library_prefix | capitalize }}_{% endif %}CircuitPython_{{ cookiecutter.library_name}}/.github/workflows/failure-help-text.yml
+++ b/{% if cookiecutter.library_prefix %}{{ cookiecutter.library_prefix | capitalize }}_{% endif %}CircuitPython_{{ cookiecutter.library_name}}/.github/workflows/failure-help-text.yml
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: 2021 Scott Shawcroft for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+
+name: Failure help text
+
+on:
+  workflow_run:
+    workflows: ["Build CI"]
+    types:
+      - completed
+
+jobs:
+  post-help:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'failure' && github.event.workflow_run.event == 'pull_request' }}
+    steps:
+    - name: Post comment to help
+      uses: adafruit/circuitpython-action-library-ci-failed@v1


### PR DESCRIPTION
Here is the PR I was testing with: https://github.com/tannewt/Adafruit_CircuitPython_TestRepo/pull/3

The new actions are here:
https://github.com/adafruit/circuitpython-action-library-ci-failed
https://github.com/adafruit/circuitpython-action-library-ci-problem-matchers

Problem matchers are helpful for surfacing errors in the logs. Where possible, they even add annotations in the PR's file view of where the issue is.