### PR TITLE
Remove "default_branch"

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -46,7 +46,6 @@ Prompts
   (e.g. ``adafruit-circuitpython-pca9685, adafruit-circuitpython-motor``). NOTE: ``Adafruit-Blinka`` is always included, so no need to include it here.
 * ``pypi_release`` - Will this library be releaased on PyPI? If so, enter ``y`` or ``yes`` to include the setup.py. For Adafruit libraries this defaults to Yes.
 * ``sphinx_docs`` - Should the Sphinx based documentation be included in your repo? If so, enter ``y`` or ``yes`` to include the setup.py. For Adafruit libraries this defaults to Yes.
-* ``default_branch`` - What is the default branch used in your Githiub repos? Choice of Master or Main. For Adafruit libraries this defaults to Master.
 
 
 Post Generation Cleanup

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -16,7 +16,6 @@
     "other_requirements": "",
     "pypi_release": "{%- if cookiecutter.target_bundle == 'Adafruit' -%} yes {%- else -%} no {%- endif -%}",
     "sphinx_docs":  "{%- if cookiecutter.target_bundle == 'Adafruit' -%} yes {%- else -%} no {%- endif -%}",
-    "default_branch": ["master", "main"],
     "_extensions": ["jinja2.ext.do"],
     "_copy_without_render": ["*.github/*"]
 }

--- a/tests/test_make_cookies.py
+++ b/tests/test_make_cookies.py
@@ -118,8 +118,6 @@ def test_new_cookiecutter_all_entries():
                 test_context[key] = 'community'
             if key == "pypi_release":
                 test_context[key] = 'yes'
-            if key == "default_branch":
-                test_context[key] = 'master'
             else:
                 test_context[key] = 'test'
         else:

--- a/{% if cookiecutter.library_prefix %}{{ cookiecutter.library_prefix | capitalize }}_{% endif %}CircuitPython_{{ cookiecutter.library_name}}/README.rst
+++ b/{% if cookiecutter.library_prefix %}{{ cookiecutter.library_prefix | capitalize }}_{% endif %}CircuitPython_{{ cookiecutter.library_name}}/README.rst
@@ -111,7 +111,7 @@ Contributing
 ============
 
 Contributions are welcome! Please read our `Code of Conduct
-<https://github.com/{{ full_repo_name }}/blob/{{cookiecutter.default_branch}}/CODE_OF_CONDUCT.md>`_
+<https://github.com/{{ full_repo_name }}/blob/HEAD/CODE_OF_CONDUCT.md>`_
 before contributing to help this project stay welcoming.
 
 Documentation


### PR DESCRIPTION
This was only used to set the URL to view the CODE-OF-CONDUCT, but it can be viewed on the default branch by using HEAD.

Closes: #124.