### PR TITLE
fix pip install instructions in readme for non-prefixed projects

### DIFF
--- a/{% if cookiecutter.library_prefix %}{{ cookiecutter.library_prefix | capitalize }}_{% endif %}CircuitPython_{{ cookiecutter.library_name}}/README.rst
+++ b/{% if cookiecutter.library_prefix %}{{ cookiecutter.library_prefix | capitalize }}_{% endif %}CircuitPython_{{ cookiecutter.library_name}}/README.rst
@@ -77,18 +77,18 @@ Installing from PyPI
 .. todo:: Remove the above note if PyPI version is/will be available at time of release.
 
 On supported GNU/Linux systems like the Raspberry Pi, you can install the driver locally `from
-PyPI <https://pypi.org/project/adafruit-circuitpython-{{ cookiecutter.library_name|lower }}/>`_.
+PyPI <https://pypi.org/project/{%- if cookiecutter.library_prefix -%}{{ cookiecutter.library_prefix }}-{%- endif -%}circuitpython-{{ cookiecutter.library_name|lower }}/>`_.
 To install for current user:
 
 .. code-block:: shell
 
-    pip3 install adafruit-circuitpython-{{ pypi_name }}
+    pip3 install {% if cookiecutter.library_prefix %}{{ cookiecutter.library_prefix }}-{% endif %}circuitpython-{{ pypi_name }}
 
 To install system-wide (this may be required in some cases):
 
 .. code-block:: shell
 
-    sudo pip3 install adafruit-circuitpython-{{ pypi_name }}
+    sudo pip3 install {% if cookiecutter.library_prefix %}{{ cookiecutter.library_prefix }}-{% endif %}circuitpython-{{ pypi_name }}
 
 To install in a virtual environment in your current project:
 
@@ -97,7 +97,7 @@ To install in a virtual environment in your current project:
     mkdir project-name && cd project-name
     python3 -m venv .env
     source .env/bin/activate
-    pip3 install adafruit-circuitpython-{{ pypi_name }}
+    pip3 install {% if cookiecutter.library_prefix -%}{{ cookiecutter.library_prefix }}-{% endif -%}circuitpython-{{ pypi_name }}
 
 {% endif %}
 


### PR DESCRIPTION
This fixes the generated readme file to include proper pip install instructions and link based on the prefix that is selected in the cookie cutter prompts.

Tested by running locally to create both adafruit and non-prefixed projects.