### PR TITLE
update github URL in setup.py to have Org if no prefix was used.

### DIFF
--- a/{% if cookiecutter.library_prefix %}{{ cookiecutter.library_prefix | capitalize }}_CircuitPython{% else %}CircuitPython_Org{% endif %}_{{ cookiecutter.library_name}}/{% if cookiecutter.pypi_release in ['y', 'yes'] %}setup.py{% endif %}
+++ b/{% if cookiecutter.library_prefix %}{{ cookiecutter.library_prefix | capitalize }}_CircuitPython{% else %}CircuitPython_Org{% endif %}_{{ cookiecutter.library_name}}/{% if cookiecutter.pypi_release in ['y', 'yes'] %}setup.py{% endif %}
@@ -27,9 +27,9 @@
     {%- set repo_name = repo_name + '_CircuitPython_' -%}
     {%- set repo_name = repo_name + cookiecutter.library_name -%}
 {%- else -%}
-    {%- set repo_name = 'CircuitPython_' + cookiecutter.library_name -%}
+    {%- set repo_name = 'CircuitPython_Org_' + cookiecutter.library_name -%}
 {%- endif -%}
-{%- set pypi_name = repo_name|lower|replace("_", "-") -%}
+{%- set pypi_name = repo_name|lower|replace("_", "-")|replace("circuitpython-org-", "circuitpython-") -%}
 """A setuptools based setup module.
 
 See:


### PR DESCRIPTION
This resolves the issue presented in [#3](https://github.com/circuitpython/CircuitPython_Org_DisplayIO_Cartesian/pull/3) in the DisplayIO_Cartesian repo. 

With these changes "Org" will get added automatically to the github URL in setup.py when prefix is blank.