### PR TITLE
Change `pid` prompt to `product_id`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,7 +37,7 @@ Prompts
 * ``library_description`` - Write a sentence describing the purpose of this library (e.g. ``CircuitPython helper library for the DC & Stepper Motor FeatherWing, Shield and Pi Hat kits.``).
 * ``library_keywords`` - Used to populate keywords for PyPi. Enter a string of keywords (e.g ``dht temp humidity``) NOTE: The following are included by default: ``adafruit``, ``blinka``, ``circuitpython``, ``micropython``, and the ``library_name`` you enter.
 * ``library_prefix`` - Used to prefix the code to the organization creating the library. For example, Adafruit supported libraries should say "adafruit" here. Do not add a - or _.
-* ``adafruit_pid`` -  The product ID for the Adafruit product includes a link to the product in the README. Only applies to Adafruit Bundle.
+* ``adafruit_product_id`` -  The product ID for the Adafruit product includes a link to the product in the README. Only applies to Adafruit Bundle.
 * ``requires_bus_device`` - Determines whether to add comments about a dependency on `BusDevice <https://github.com/adafruit/Adafruit_CircuitPython_BusDevice>`_.
   If the library uses BusDevice, enter ``y`` or ``yes`` to include. If the library doesn't use BusDevice, all other entries including empty, will not include BusDevice.
 * ``requires_register`` - Determines whether to add comments about a dependency on `Register <https://github.com/adafruit/Adafruit_CircuitPython_Register>`_.

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -11,7 +11,7 @@
     "library_description": "",
     "library_keywords": "",
     "library_prefix": "{%- if cookiecutter.target_bundle == 'Adafruit' -%} adafruit {%- endif -%}",
-    "adafruit_project_id": "",
+    "adafruit_product_id": "",
     "requires_bus_device": "",
     "requires_register": "",
     "other_requirements": "",

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -11,7 +11,7 @@
     "library_description": "",
     "library_keywords": "",
     "library_prefix": "{%- if cookiecutter.target_bundle == 'Adafruit' -%} adafruit {%- endif -%}",
-    "adafruit_pid": "",
+    "adafruit_project_id": "",
     "requires_bus_device": "",
     "requires_register": "",
     "other_requirements": "",

--- a/{{ cookiecutter and 'tmp_repo' }}/README.rst
+++ b/{{ cookiecutter and 'tmp_repo' }}/README.rst
@@ -67,7 +67,7 @@ or individual libraries can be installed using
 .. todo:: Describe the Adafruit product this library works with. For PCBs, you can also add the
 image from the assets folder in the PCB's GitHub repo.
 
-`Purchase one from the Adafruit shop <http://www.adafruit.com/products/{{cookiecutter.adafruit_pid}}>`_
+`Purchase one from the Adafruit shop <http://www.adafruit.com/products/{{cookiecutter.adafruit_product_id}}>`_
 {% endif -%}
 
 {%- if cookiecutter.pypi_release in  ["y", "yes"] %}


### PR DESCRIPTION
Close #152 by switching the `adafruit_pid` prompt to `adafruit_product_id`.

P.S. to maintainers: could you please label this pull request with `hacktoberfest-accepted` after you merge it so it counts for Hacktoberfest? Thanks!