### PR TITLE
fix newlines near import comment and version string

### DIFF
--- a/{{ cookiecutter and 'tmp_repo' }}/{% if cookiecutter.library_prefix %}{{ cookiecutter.library_prefix | lower | replace(" ", "_") }}_{% endif %}{{ cookiecutter.library_name | lower | replace(" ", "_") }}.py
+++ b/{{ cookiecutter and 'tmp_repo' }}/{% if cookiecutter.library_prefix %}{{ cookiecutter.library_prefix | lower | replace(" ", "_") }}_{% endif %}{{ cookiecutter.library_name | lower | replace(" ", "_") }}.py
@@ -36,7 +36,7 @@ Implementation Notes
 
 # imports
 
-{%- if cookiecutter.target_bundle != 'CircuitPython Org' -%}
+{% if cookiecutter.target_bundle != 'CircuitPython Org' -%}
     {%- if cookiecutter.library_prefix -%}
         {%- set repo_name = (cookiecutter.library_prefix | capitalize) -%}
         {%- set repo_name = repo_name + '_CircuitPython_' -%}
@@ -45,9 +45,9 @@ Implementation Notes
         {%- set repo_name = 'CircuitPython_' -%}
         {%- set repo_name = repo_name + cookiecutter.library_name | replace(" ", "_") -%}
     {%- endif -%}
-{%- else -%}
+{% else -%}
     {%- set repo_name = 'CircuitPython_Org_' + cookiecutter.library_name | replace(" ", "_") -%}
-{%- endif -%}
+{% endif -%}
 
 __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/{{ cookiecutter.github_user }}/{{ repo_name }}.git"


### PR DESCRIPTION
resolves #161 

Add some newlines between the imports comment and the version string variable.

Tested successfully, with this version that portion of the generated file looks like this:
```py

# imports

__version__ = "0.0.0-auto.0"
__repo__ = "https://github.com/foamyguy/CircuitPython_test_newlines_again.git"
```