### PR TITLE
Don't use specific CPython versions

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v1
-    - uses: actions/setup-python@v1
+    - uses: actions/setup-python@v2
     - name: set PY
       run: echo >>$GITHUB_ENV "PY=$(python -c 'import hashlib, sys;print(hashlib.sha256(sys.version.encode()+sys.executable.encode()).hexdigest())')"
     - uses: actions/cache@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,10 +14,10 @@ jobs:
       env:
         GITHUB_CONTEXT: ${{ toJson(github) }}
       run: echo "$GITHUB_CONTEXT"
-    - name: Set up Python 3.6
-      uses: actions/setup-python@v1
+    - name: Set up Python 3.x
+      uses: actions/setup-python@v2
       with:
-        python-version: 3.6
+        python-version: "3.x"
     - name: Versions
       run: |
         python3 --version

--- a/conf.py
+++ b/conf.py
@@ -356,5 +356,5 @@ texinfo_documents = [
 #
 # texinfo_no_detailmenu = False
 
-intersphinx_mapping = {'python': ('https://docs.python.org/3.4', None),
+intersphinx_mapping = {'python': ('https://docs.python.org/3', None),
                        'CircuitPython': ('https://circuitpython.readthedocs.io/en/latest/', None)}

--- a/{{ cookiecutter and 'tmp_repo' }}/.github/workflows/build.yml
+++ b/{{ cookiecutter and 'tmp_repo' }}/.github/workflows/build.yml
@@ -22,10 +22,10 @@ jobs:
         awk -F '\/' '{ print tolower($2) }' |
         tr '_' '-'
         )
-    - name: Set up Python 3.7
-      uses: actions/setup-python@v1
+    - name: Set up Python 3.x
+      uses: actions/setup-python@v2
       with:
-        python-version: 3.7
+        python-version: "3.x"
     - name: Versions
       run: |
         python3 --version

--- a/{{ cookiecutter and 'tmp_repo' }}/.github/workflows/release.yml
+++ b/{{ cookiecutter and 'tmp_repo' }}/.github/workflows/release.yml
@@ -24,10 +24,10 @@ jobs:
         awk -F '\/' '{ print tolower($2) }' |
         tr '_' '-'
         )
-    - name: Set up Python 3.6
-      uses: actions/setup-python@v1
+    - name: Set up Python 3.x
+      uses: actions/setup-python@v2
       with:
-        python-version: 3.6
+        python-version: "3.x"
     - name: Versions
       run: |
         python3 --version
@@ -67,7 +67,7 @@ jobs:
         echo ::set-output name=setup-py::$( find . -wholename './setup.py' )
     - name: Set up Python
       if: contains(steps.need-pypi.outputs.setup-py, 'setup.py')
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: '3.x'
     - name: Install dependencies

--- a/{{ cookiecutter and 'tmp_repo' }}/docs/conf.py
+++ b/{{ cookiecutter and 'tmp_repo' }}/docs/conf.py
@@ -29,7 +29,7 @@ extensions = [
 
 
 intersphinx_mapping = {
-    "python": ("https://docs.python.org/3.4", None),
+    "python": ("https://docs.python.org/3", None),
     {%- if cookiecutter.requires_bus_device in ["y", "yes"] -%}
     "BusDevice": ("https://circuitpython.readthedocs.io/projects/busdevice/en/latest/", None),
     {% endif %}

--- a/{{ cookiecutter and 'tmp_repo' }}/{% if cookiecutter.pypi_release in ['y', 'yes'] %}setup.py{% endif %}
+++ b/{{ cookiecutter and 'tmp_repo' }}/{% if cookiecutter.pypi_release in ['y', 'yes'] %}setup.py{% endif %}
@@ -89,8 +89,6 @@ setup(
         "Topic :: System :: Hardware",
         "License :: OSI Approved :: MIT License",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.4",
-        "Programming Language :: Python :: 3.5",
     ],
     # What does your project relate to?
     keywords="{{ kw_list.kw_list|sort|unique|join(' "\n"')|indent(width=13) }}",

--- a/{{ cookiecutter and 'tmp_repo' }}/{% if cookiecutter.sphinx_docs in ['y', 'yes'] %}.readthedocs.yaml{% endif %}
+++ b/{{ cookiecutter and 'tmp_repo' }}/{% if cookiecutter.sphinx_docs in ['y', 'yes'] %}.readthedocs.yaml{% endif %}
@@ -9,7 +9,7 @@
 version: 2
 
 python:
-  version: "3.6"
+  version: "3.x"
   install:
     - requirements: docs/requirements.txt
     - requirements: requirements.txt


### PR DESCRIPTION
Requiring a specific version of Python in CI actions is getting us into trouble when newer versions of packages either expect or require newer versions of python. The package might not get updated properly, because pip will hold it back.

- Specify Python `3.x` in this repos' CI actions, and in the cookiecutter actions it creates.
- Set `intersphinx_mapping` to Python 3 instead of 3.4. Now that MicroPython has started implementing some selected features from later versions of Python, holding the doc back to 3.4 can be incorrect. We may as well keep up. It may still be wrong, but it is likely to be less wrong.
- In the cookiecutter `setup.py`, specify compatibility simply as Python 3, instead of 3.4 and 3.5.

If this is approved, then the libraries should be updated in a sweep to use these changes.