### PR TITLE
add docs link to documentation section in readme

### DIFF
--- a/{{ cookiecutter and 'tmp_repo' }}/README.rst
+++ b/{{ cookiecutter and 'tmp_repo' }}/README.rst
@@ -11,15 +11,21 @@
 {%- endif -%}
 {%- set full_repo_name = cookiecutter.github_user + "/" + repo_name -%}
 {%- set pypi_name = cookiecutter.library_name|lower|replace("_", "-")|replace(" ", "-") -%}
+{%- if cookiecutter.target_bundle == 'Adafruit' %}
+    {%- set docs_url = 'https://docs.circuitpython.org/projects/' + cookiecutter.library_name | lower | replace(" ", "-") + '/en/latest/' -%}
+{%- else %}
+    {%- set docs_url = 'https://circuitpython-' + cookiecutter.library_name | lower | replace(" ", "-") | replace("_", "-") + '.readthedocs.io/' -%}
+{%- endif %}
+
 Introduction
 ============
 
 {% if cookiecutter.sphinx_docs | lower in ["yes", "y"] %}
 .. image:: https://readthedocs.org/projects/{% if cookiecutter.library_prefix %}{{ cookiecutter.library_prefix | lower | replace("_", "-")}}-{% endif %}circuitpython-{{ cookiecutter.library_name | lower | replace(" ", "-") | replace("_", "-") }}/badge/?version=latest
 {%- if cookiecutter.target_bundle == 'Adafruit' %}
-    :target: https://docs.circuitpython.org/projects/{{ cookiecutter.library_name | lower | replace(" ", "-") }}/en/latest/
+    :target: {{ docs_url }}
 {%- else %}
-    :target: https://circuitpython-{{ cookiecutter.library_name | lower | replace(" ", "-") | replace("_", "-") }}.readthedocs.io/
+    :target: {{ docs_url }}
 {%- endif %}
     :alt: Documentation Status
 {% endif %}
@@ -142,6 +148,7 @@ before contributing to help this project stay welcoming.
 
 Documentation
 =============
+API documentation for this library can be found on `Read the Docs <{{ docs_url }}>`_.
 
 For information on building library documentation, please check out
 `this guide <https://learn.adafruit.com/creating-and-sharing-a-circuitpython-library/sharing-our-docs-on-readthedocs#sphinx-5-1>`_.

--- a/{{ cookiecutter and 'tmp_repo' }}/README.rst
+++ b/{{ cookiecutter and 'tmp_repo' }}/README.rst
@@ -11,12 +11,11 @@
 {%- endif -%}
 {%- set full_repo_name = cookiecutter.github_user + "/" + repo_name -%}
 {%- set pypi_name = cookiecutter.library_name|lower|replace("_", "-")|replace(" ", "-") -%}
-{%- if cookiecutter.target_bundle == 'Adafruit' %}
+{%- if cookiecutter.target_bundle == 'Adafruit' -%}
     {%- set docs_url = 'https://docs.circuitpython.org/projects/' + cookiecutter.library_name | lower | replace(" ", "-") + '/en/latest/' -%}
-{%- else %}
+{%- else -%}
     {%- set docs_url = 'https://circuitpython-' + cookiecutter.library_name | lower | replace(" ", "-") | replace("_", "-") + '.readthedocs.io/' -%}
-{%- endif %}
-
+{%- endif -%}
 Introduction
 ============
 


### PR DESCRIPTION
resolves #166

I broke out the `docs_url` into a variable that gets set once at the top when some other variables are initialized. Then that variable gets used for both docs badge link and the new docs link inside the documentation section.

Tested by running cookiecutter locally with all 3 bundle types. All seemed to show the expected URLs for the docs.

I filled in the name for a real library (Nunchuk) and confirmed that the generated README.rst does point to the correct docs pages for that real library.
![image](https://user-images.githubusercontent.com/2406189/151463930-ae8676fc-f84b-43ac-847f-324a28df492b.png)
