### PR TITLE
Fix cookiecutter issues

### DIFF
--- a/{{ cookiecutter and 'tmp_repo' }}/README.rst
+++ b/{{ cookiecutter and 'tmp_repo' }}/README.rst
@@ -138,16 +138,16 @@ Usage Example
 .. todo:: Add a quick, simple example. It and other examples should live in the
 examples folder and be included in docs/examples.rst.
 
-Contributing
-============
-
-Contributions are welcome! Please read our `Code of Conduct
-<https://github.com/{{ full_repo_name }}/blob/HEAD/CODE_OF_CONDUCT.md>`_
-before contributing to help this project stay welcoming.
-
 Documentation
 =============
 API documentation for this library can be found on `Read the Docs <{{ docs_url }}>`_.
 
 For information on building library documentation, please check out
 `this guide <https://learn.adafruit.com/creating-and-sharing-a-circuitpython-library/sharing-our-docs-on-readthedocs#sphinx-5-1>`_.
+
+Contributing
+============
+
+Contributions are welcome! Please read our `Code of Conduct
+<https://github.com/{{ full_repo_name }}/blob/HEAD/CODE_OF_CONDUCT.md>`_
+before contributing to help this project stay welcoming.

--- a/{{ cookiecutter and 'tmp_repo' }}/{% if cookiecutter.library_prefix %}{{ cookiecutter.library_prefix | lower | replace(" ", "_") }}_{% endif %}{{ cookiecutter.library_name | lower | replace(" ", "_") }}.py
+++ b/{{ cookiecutter and 'tmp_repo' }}/{% if cookiecutter.library_prefix %}{{ cookiecutter.library_prefix | lower | replace(" ", "_") }}_{% endif %}{{ cookiecutter.library_name | lower | replace(" ", "_") }}.py
@@ -25,7 +25,7 @@ Implementation Notes
 **Software and Dependencies:**
 
 * Adafruit CircuitPython firmware for the supported boards:
-  https://github.com/adafruit/circuitpython/releases
+  https://circuitpython.org/downloads
 
 .. todo:: Uncomment or remove the Bus Device and/or the Register library dependencies
   based on the library's use of either.


### PR DESCRIPTION
1. Update link for CircuitPython firmware download
2. Swap Documentation and Contributing sections in README