### PR TITLE
Please test: Update chat badge and .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,16 +1,31 @@
-# SPDX-FileCopyrightText: 2017 Scott Shawcroft, written for Adafruit Industries
+# SPDX-FileCopyrightText: 2022 Kattni Rembor, written for Adafruit Industries
 #
-# SPDX-License-Identifier: Unlicense
+# SPDX-License-Identifier: MIT
 
-.venv
-.env
-.python-version
+# cookiecutter-specific files
+.cookie_test/
+.pytest*
 
+# CircuitPython-specific files
+*.mpy
+
+# Python-specific files
+__pycache__
 *.pyc
 
-.pytest*
-__pycache__
+# Sphinx build-specific files
+_build
 
-.cookie_test/
+# This file results from running `pip -e install .` in a local repository
+*.egg-info
 
-.vscode/
+# Virtual environment-specific files
+.env
+
+# MacOS-specific files
+*.DS_Store
+
+# IDE-specific files
+.idea
+.vscode
+*~

--- a/{{ cookiecutter and 'tmp_repo' }}/README.rst
+++ b/{{ cookiecutter and 'tmp_repo' }}/README.rst
@@ -29,7 +29,11 @@ Introduction
     :alt: Documentation Status
 {% endif %}
 
+{%- if cookiecutter.target_bundle == 'Adafruit' %}
+.. image:: https://github.com/adafruit/Adafruit_CircuitPython_Bundle/blob/main/badges/adafruit_discord.svg
+{%- else %}
 .. image:: https://img.shields.io/discord/327254708534116352.svg
+{% endif %}
     :target: https://adafru.it/discord
     :alt: Discord
 

--- a/{{ cookiecutter and 'tmp_repo' }}/README.rst
+++ b/{{ cookiecutter and 'tmp_repo' }}/README.rst
@@ -29,11 +29,11 @@ Introduction
     :alt: Documentation Status
 {% endif %}
 
-{%- if cookiecutter.target_bundle == 'Adafruit' -%}
+{% if cookiecutter.target_bundle == 'Adafruit' -%}
 .. image:: https://github.com/adafruit/Adafruit_CircuitPython_Bundle/blob/main/badges/adafruit_discord.svg
-{%- else -%}
+{%- else %}
 .. image:: https://img.shields.io/discord/327254708534116352.svg
-{%- endif -%}
+{%- endif %}
     :target: https://adafru.it/discord
     :alt: Discord
 

--- a/{{ cookiecutter and 'tmp_repo' }}/README.rst
+++ b/{{ cookiecutter and 'tmp_repo' }}/README.rst
@@ -29,11 +29,11 @@ Introduction
     :alt: Documentation Status
 {% endif %}
 
-{%- if cookiecutter.target_bundle == 'Adafruit' %}
+{%- if cookiecutter.target_bundle == 'Adafruit' -%}
 .. image:: https://github.com/adafruit/Adafruit_CircuitPython_Bundle/blob/main/badges/adafruit_discord.svg
-{%- else %}
+{%- else -%}
 .. image:: https://img.shields.io/discord/327254708534116352.svg
-{% endif %}
+{%- endif -%}
     :target: https://adafru.it/discord
     :alt: Discord
 


### PR DESCRIPTION
Updating to Adafruit Discord chat badge for Adafruit bundle only.

Updated the top-level cookiecutter .gitignore to match the globally updated .gitignore, with a couple of extras from the original that look cookiecutter-specific.

Please test that this generates properly for both the Adafruit and Community library options before merging. Thanks!