### PR TITLE
Check cookiecutter version

### DIFF
--- a/hooks/pre_gen_project.py
+++ b/hooks/pre_gen_project.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2022 Alec Delaney, written for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+
 import cookiecutter
 
 MIN_VERSION = 2.1

--- a/hooks/pre_gen_project.py
+++ b/hooks/pre_gen_project.py
@@ -6,6 +6,6 @@ semver = cookiecutter.__version__
 major, minor, _ = semver.split(".")
 maj_min_ver = float(major + "." + minor)
 
-if maj_min_ver >= MIN_VERSION:
+if maj_min_ver < MIN_VERSION:
     print("cookiecutter must be at a minimum of version", MIN_VERSION)
     raise SystemExit(1)

--- a/hooks/pre_gen_project.py
+++ b/hooks/pre_gen_project.py
@@ -3,14 +3,15 @@
 # SPDX-License-Identifier: MIT
 
 import cookiecutter
+from pkg_resources import packaging
 
-MIN_VERSION = 2.1
+MIN_VERSION_SEMVER = "2.1"
+MIN_VERSION = packaging.version.parse(MIN_VERSION_SEMVER)
 
-semver = cookiecutter.__version__
-major, minor, _ = semver.split(".")
-maj_min_ver = float(major + "." + minor)
+user_version_semver = cookiecutter.__version__
+user_version = packaging.version.parse(user_semver)
 
-if maj_min_ver < MIN_VERSION:
+if MIN_VERSION > user_version:
     print("")
     print("!!! cookiecutter must be at a minimum of version", MIN_VERSION, "!!!")
     print("")

--- a/hooks/pre_gen_project.py
+++ b/hooks/pre_gen_project.py
@@ -9,7 +9,7 @@ MIN_VERSION_SEMVER = "2.1"
 MIN_VERSION = packaging.version.parse(MIN_VERSION_SEMVER)
 
 user_version_semver = cookiecutter.__version__
-user_version = packaging.version.parse(user_semver)
+user_version = packaging.version.parse(user_version_semver)
 
 if MIN_VERSION > user_version:
     print("")

--- a/hooks/pre_gen_project.py
+++ b/hooks/pre_gen_project.py
@@ -7,5 +7,7 @@ major, minor, _ = semver.split(".")
 maj_min_ver = float(major + "." + minor)
 
 if maj_min_ver < MIN_VERSION:
-    print("cookiecutter must be at a minimum of version", MIN_VERSION)
+    print("")
+    print("!!! cookiecutter must be at a minimum of version", MIN_VERSION, "!!!")
+    print("")
     raise SystemExit(1)

--- a/hooks/pre_gen_project.py
+++ b/hooks/pre_gen_project.py
@@ -1,0 +1,11 @@
+import cookiecutter
+
+MIN_VERSION = 2.1
+
+semver = cookiecutter.__version__
+major, minor, _ = semver.split(".")
+maj_min_ver = float(major + "." + minor)
+
+if maj_min_ver >= MIN_VERSION:
+    print("cookiecutter must be at a minimum of version", MIN_VERSION)
+    raise SystemExit(1)


### PR DESCRIPTION
Spawned from the conversation on Discord, this new pre-generation hook will check the version of `cookiecutter` against a minimum version, which has the added benefit of allowing us to notify the user to upgrade.