### PR TITLE
Update Adafruit Discord badge

### DIFF
--- a/{{ cookiecutter.__dirname }}/README.rst
+++ b/{{ cookiecutter.__dirname }}/README.rst
@@ -30,7 +30,7 @@ Introduction
 {% endif %}
 
 {% if cookiecutter.target_bundle == 'Adafruit' -%}
-.. image:: https://github.com/adafruit/Adafruit_CircuitPython_Bundle/blob/main/badges/adafruit_discord.svg
+.. image:: https://raw.githubusercontent.com/adafruit/Adafruit_CircuitPython_Bundle/main/badges/adafruit_discord.svg
 {%- else %}
 .. image:: https://img.shields.io/discord/327254708534116352.svg
 {%- endif %}


### PR DESCRIPTION
This updates the cookiecutter to use an image for the Adafruit Discord badge that will render properly for ReadTheDocs.

Noticed in https://github.com/adafruit/Adafruit_CircuitPython_SI1145/pull/7