### PR TITLE
Update README to mention new cookiecutter minimum version

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,7 @@ Cookiecutter Usage
 .. code-block:: bash
 
   # The first time
-  pip install cookiecutter@https://github.com/cookiecutter/cookiecutter/archive/2.0.2.zip
+  pip install cookiecutter~=2.1
 
   cookiecutter gh:adafruit/cookiecutter-adafruit-circuitpython
 


### PR DESCRIPTION
New minimum version is 2.1, so this updates the README with the updated version for first time installation.