### PR TITLE
Mpy size actions

### DIFF
--- a/{{ cookiecutter.__dirname }}/.github/workflows/build.yml
+++ b/{{ cookiecutter.__dirname }}/.github/workflows/build.yml
@@ -62,7 +62,7 @@ jobs:
       if: github.event_name == 'pull_request'
       uses: machine-learning-apps/pr-comment@master
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: {% raw %}${{ secrets.GITHUB_TOKEN }} {% endraw %}
       with:
         path: sizes.txt
     - name: Archive bundles

--- a/{{ cookiecutter.__dirname }}/.github/workflows/build.yml
+++ b/{{ cookiecutter.__dirname }}/.github/workflows/build.yml
@@ -54,6 +54,17 @@ jobs:
         pre-commit run --all-files
     - name: Build assets
       run: circuitpython-build-bundles --filename_prefix {% raw %}${{ steps.repo-name.outputs.repo-name }}{% endraw -%} {% if cookiecutter.target_bundle == 'Community' %} --package_folder_prefix {% if cookiecutter.library_prefix -%} {{ cookiecutter.library_prefix | lower | replace(' ', '_') }}_ {%- else %}""{%- endif -%}{%- endif %} --library_location .
+    - name: Check Sizes
+      run: |
+        git clone https://github.com/FoamyGuy/CircuitPython_Memory_Tools.git
+        python CircuitPython_Memory_Tools/measure_size.py > sizes.txt
+    - name: Size Measurement Comment
+      if: github.event_name == 'pull_request'
+      uses: machine-learning-apps/pr-comment@master
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        path: sizes.txt
     - name: Archive bundles
       uses: actions/upload-artifact@v2
       with:


### PR DESCRIPTION
This change adds two actions task inside the generated library repo that will post a comment on PRs with information about mpy file sizes. 

This is an example of the comments that it posts:
https://github.com/FoamyGuy/Adafruit_CircuitPython_SI1145/pull/1#issuecomment-1218727386

Some outstanding things to consider:

-  The script that finds the sizes and compiles them into a suitable string is housed in this repo currently: https://github.com/FoamyGuy/CircuitPython_Memory_Tools/blob/main/measure_size.py it could be moved to adabot, build-tools, or somewhere else, maybe a new repo under adafruit?
- Do we want to change the wording any? I wrote the current ones, but there may be room for improvement. Do we want any other stats in the comment? The difference between sizes of each version perhaps?
- Should it print any of the size checking or `strings` output into the actions output? Currently there are minimal prints that make it to actions, most things are in the comment rather than the actions output.
- Should the comment be conditional on sizes being a big enough difference?
- Probably would be good to test `measure_size.py` against more libraries. I've done one of each: package and module, but not much else. There may be library structures that confuse it.