### PR TITLE
Upgrade cookiecutter (and its infrastructure) to actions/checkout@v3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
       run: |
         python3 --version
     - name: Checkout Current Repo
-      uses: actions/checkout@v1
+      uses: actions/checkout@v3
       with:
         submodules: true
     - name: Install deps

--- a/{{ cookiecutter.__dirname }}/.github/workflows/build.yml
+++ b/{{ cookiecutter.__dirname }}/.github/workflows/build.yml
@@ -30,11 +30,11 @@ jobs:
       run: |
         python3 --version
     - name: Checkout Current Repo
-      uses: actions/checkout@v1
+      uses: actions/checkout@v3
       with:
         submodules: true
     - name: Checkout tools repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         repository: adafruit/actions-ci-circuitpython-libs
         path: actions-ci

--- a/{{ cookiecutter.__dirname }}/.github/workflows/release.yml
+++ b/{{ cookiecutter.__dirname }}/.github/workflows/release.yml
@@ -32,11 +32,11 @@ jobs:
       run: |
         python3 --version
     - name: Checkout Current Repo
-      uses: actions/checkout@v1
+      uses: actions/checkout@v3
       with:
         submodules: true
     - name: Checkout tools repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         repository: adafruit/actions-ci-circuitpython-libs
         path: actions-ci
@@ -60,7 +60,7 @@ jobs:
   upload-pypi:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Check For pyproject.toml
       id: need-pypi
       run: |


### PR DESCRIPTION
Resolves #164 but with the newer V3

Linked with the corresponding library patch:  https://github.com/adafruit/adabot/pull/293