### PR TITLE
Update README to use .venv for virtual environment name

### DIFF
--- a/{{ cookiecutter.__dirname }}/.gitignore
+++ b/{{ cookiecutter.__dirname }}/.gitignore
@@ -37,6 +37,7 @@ _build
 
 # Virtual environment-specific files
 .env
+.venv
 
 # MacOS-specific files
 *.DS_Store

--- a/{{ cookiecutter.__dirname }}/README.rst
+++ b/{{ cookiecutter.__dirname }}/README.rst
@@ -107,7 +107,7 @@ To install in a virtual environment in your current project:
 .. code-block:: shell
 
     mkdir project-name && cd project-name
-    python3 -m venv .env
+    python3 -m venv .venv
     source .env/bin/activate
     pip3 install {% if cookiecutter.library_prefix -%}{{ cookiecutter.library_prefix }}-{% endif -%}circuitpython-{{ pypi_name }}
 


### PR DESCRIPTION
With web workflow using an `.env` file, READMEs for libraries now suggest using `.venv` for virtual environment name.  This is the corresponding cookiecutter patch.