### PR TITLE
don't run tests twice

### DIFF
--- a/{{ cookiecutter.__dirname }}/.github/workflows/build.yml
+++ b/{{ cookiecutter.__dirname }}/.github/workflows/build.yml
@@ -4,7 +4,13 @@
 
 name: Build CI
 
-on: [pull_request, push]
+on:
+  # only run tests on push to main
+  push:
+    branches:
+      - main
+  # run tests for all pull requests
+  pull_request:
 
 jobs:
   test:


### PR DESCRIPTION
currently tests are run twice, both for the pull request and the push to the branch. The proposed change makes sure tests are only run once, speeding up CI run.