### PR TITLE
Set autodoc to preserve default arguments

### DIFF
--- a/{{ cookiecutter.__dirname }}/docs/{% if cookiecutter.sphinx_docs in ['y', 'yes'] %}conf.py{% endif %}
+++ b/{{ cookiecutter.__dirname }}/docs/{% if cookiecutter.sphinx_docs in ['y', 'yes'] %}conf.py{% endif %}
@@ -28,6 +28,8 @@ extensions = [
 # autodoc module docs will fail to generate with a warning.
 # autodoc_mock_imports = ["digitalio", "busio"]
 
+autodoc_preserve_defaults = True
+
 
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),


### PR DESCRIPTION
Fixes #170, which I think is a more readable way to show `Enum`-like things in the documentation especially when we aren't actually using `enum.Enum` because it doesn't exist in CircuitPython.  This would result in a patch to the libraries to add this in there.