### PR TITLE
Add note regarding package-prefix

### DIFF
--- a/{{ cookiecutter.__dirname }}/.github/workflows/release_gh.yml
+++ b/{{ cookiecutter.__dirname }}/.github/workflows/release_gh.yml
@@ -16,4 +16,9 @@ jobs:
       uses: adafruit/workflows-circuitpython-libs/release-gh@main
       with:
         github-token: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
-        upload-url: {% raw %}${{ github.event.release.upload_url }}{% endraw %}
+        upload-url: {% raw %}${{ github.event.release.upload_url }}{% endraw %}{% if cookiecutter.target_bundle != 'Adafruit' %}
+        # TODO: If you're creating a package (library is a folder), add this
+        # argument along with the prefix (or full name) of the package folder
+        # so the  MPY bundles are built correctly:s
+        # package-prefix: {{ cookiecutter.__libprefix }}{{ cookiecutter.__libname }}
+{%- endif %}


### PR DESCRIPTION
Adds note to help prevent https://github.com/adafruit/workflows-circuitpython-libs/issues/15 in the future.  It's only needed for non-Adafruit libraries.  Placing the Jinja tags the way I've done prevents unnecssary whitespace from being generated so `black` won't automatically need to address it (I tried using `%-` and such but didn't get it to line up any other way.