### PR TITLE
Update pylintrc, fix jQuery for docs

### DIFF
--- a/{{ cookiecutter.__dirname }}/.pylintrc
+++ b/{{ cookiecutter.__dirname }}/.pylintrc
@@ -396,4 +396,4 @@ min-public-methods=1
 
 # Exceptions that will emit a warning when being caught. Defaults to
 # "Exception"
-overgeneral-exceptions=Exception
+overgeneral-exceptions=builtins.Exception

--- a/{{ cookiecutter.__dirname }}/docs/{% if cookiecutter.sphinx_docs in ['y', 'yes'] %}conf.py{% endif %}
+++ b/{{ cookiecutter.__dirname }}/docs/{% if cookiecutter.sphinx_docs in ['y', 'yes'] %}conf.py{% endif %}
@@ -17,6 +17,7 @@ sys.path.insert(0, os.path.abspath(".."))
 # ones.
 extensions = [
     "sphinx.ext.autodoc",
+    "sphinxcontrib.jquery",
     "sphinx.ext.intersphinx",
     "sphinx.ext.napoleon",
     "sphinx.ext.todo",

--- a/{{ cookiecutter.__dirname }}/docs/{% if cookiecutter.sphinx_docs in ['y', 'yes'] %}requirements.txt{% endif %}
+++ b/{{ cookiecutter.__dirname }}/docs/{% if cookiecutter.sphinx_docs in ['y', 'yes'] %}requirements.txt{% endif %}
@@ -3,3 +3,4 @@
 # SPDX-License-Identifier: Unlicense
 
 sphinx>=4.0.0
+sphinxcontrib-jquery


### PR DESCRIPTION
- Updates `.pylintrc` to specify exceptions per `pylint` warning
- Fixes jQuery for Sphinx