### PR TITLE
fix rtd theme

### DIFF
--- a/{{ cookiecutter.__dirname }}/docs/{% if cookiecutter.sphinx_docs in ['y', 'yes'] %}conf.py{% endif %}
+++ b/{{ cookiecutter.__dirname }}/docs/{% if cookiecutter.sphinx_docs in ['y', 'yes'] %}conf.py{% endif %}
@@ -118,19 +118,10 @@ napoleon_numpy_docstring = False
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-on_rtd = os.environ.get("READTHEDOCS", None) == "True"
+import sphinx_rtd_theme
 
-if not on_rtd:  # only import and set the theme if we're building docs locally
-    try:
-        import sphinx_rtd_theme
-
-        html_theme = "sphinx_rtd_theme"
-        html_theme_path = [sphinx_rtd_theme.get_html_theme_path(), "."]
-    except:
-        html_theme = "default"
-        html_theme_path = ["."]
-else:
-    html_theme_path = ["."]
+html_theme = "sphinx_rtd_theme"
+html_theme_path = [sphinx_rtd_theme.get_html_theme_path(), "."]
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,


### PR DESCRIPTION
Same fix from: https://github.com/adafruit/Adafruit_CircuitPython_TestRepo/pull/49 

as well as in the core: https://github.com/adafruit/circuitpython/pull/8322

I've confirmed successful rtd builds with the test repo using this fix: https://readthedocs.org/projects/adafruit-circuitpython-testrepo/builds/