### PR TITLE
unpin sphinx version, add spinx-rtd-theme to docs/requirements.txt

### DIFF
--- a/{{ cookiecutter.__dirname }}/docs/{% if cookiecutter.sphinx_docs in ['y', 'yes'] %}requirements.txt{% endif %}
+++ b/{{ cookiecutter.__dirname }}/docs/{% if cookiecutter.sphinx_docs in ['y', 'yes'] %}requirements.txt{% endif %}
@@ -2,5 +2,6 @@
 #
 # SPDX-License-Identifier: Unlicense
 
-sphinx>=4.0.0
+sphinx
 sphinxcontrib-jquery
+sphinx-rtd-theme


### PR DESCRIPTION
This change goes along with https://github.com/adafruit/adabot/pull/360

Unpin `Sphinx` version and add `sphinx-rtd-theme` to docs/requirements.txt so that it gets installed when the build runs inside of RTD.