### PR TITLE
build: add setuptools as dependency to support python 3.12

### DIFF
--- a/tests_requirements.txt
+++ b/tests_requirements.txt
@@ -4,3 +4,4 @@
 
 cookiecutter >= 2.1.0
 pytest
+setuptools


### PR DESCRIPTION
python 3.12 dropped distutils which seems to break everything.  adding `setuptools` to the test_requirements.txt seems to allow us to run the tests correctly