### PR TITLE
Update rtd build container configuration value

### DIFF
--- a/{{ cookiecutter.__dirname }}/{% if cookiecutter.sphinx_docs in ['y', 'yes'] %}.readthedocs.yaml{% endif %}
+++ b/{{ cookiecutter.__dirname }}/{% if cookiecutter.sphinx_docs in ['y', 'yes'] %}.readthedocs.yaml{% endif %}
@@ -9,7 +9,7 @@
 version: 2
 
 build:
-  os: ubuntu-latest
+  os: ubuntu-lts-latest
   tools:
     python: "3"
 


### PR DESCRIPTION
the  value `ubuntu-latest` is not supported by RTD, it causes this build error:

> Error
   Config validation error in build.os. Expected one of (ubuntu-20.04, ubuntu-22.04, ubuntu-24.04, ubuntu-lts-latest), got   type str (ubuntu-latest). Double check the type of the value. A string may be required (e.g. "3.10" instead of 3.10)


Their supported constant for "latest supported version" is `ubuntu-lts-latest` https://docs.readthedocs.io/en/stable/config-file/v2.html#build-os