### PR TITLE
Changes to make fresh project pass precommit and docs build

### DIFF
--- a/{{ cookiecutter.__dirname }}/docs/{% if cookiecutter.sphinx_docs in ['y', 'yes'] %}api.rst{% endif %}
+++ b/{{ cookiecutter.__dirname }}/docs/{% if cookiecutter.sphinx_docs in ['y', 'yes'] %}api.rst{% endif %}
@@ -4,5 +4,8 @@
 .. If your library file(s) are nested in a directory (e.g. /adafruit_foo/foo.py)
 .. use this format as the module name: "adafruit_foo.foo"
 
+API Reference
+#############
+
 .. automodule:: {% if cookiecutter.library_prefix %}{{ cookiecutter.library_prefix | lower }}_{% endif %}{{ cookiecutter.library_name | lower | replace(" ", "_") }}
     :members:

--- a/{{ cookiecutter.__dirname }}/docs/{% if cookiecutter.sphinx_docs in ['y', 'yes'] %}conf.py{% endif %}
+++ b/{{ cookiecutter.__dirname }}/docs/{% if cookiecutter.sphinx_docs in ['y', 'yes'] %}conf.py{% endif %}
@@ -29,18 +29,35 @@ extensions = [
 
 autodoc_preserve_defaults = True
 
-
+{% if cookiecutter.requires_bus_device in ["y", "yes"] and cookiecutter.requires_register in ["y", "yes"] -%}
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
-    {% if cookiecutter.requires_bus_device in ["y", "yes"] -%}
     "BusDevice": ("https://docs.circuitpython.org/projects/busdevice/en/latest/", None),
-    {%- endif %}
-    {% if cookiecutter.requires_register in ["y", "yes"] -%}
     "Register": ("https://docs.circuitpython.org/projects/register/en/latest/", None),
-    {%- endif %}
     "CircuitPython": ("https://docs.circuitpython.org/en/latest/", None),
 }
 
+{% elif cookiecutter.requires_bus_device in ["y", "yes"] -%}
+intersphinx_mapping = {
+    "python": ("https://docs.python.org/3", None),
+    "BusDevice": ("https://docs.circuitpython.org/projects/busdevice/en/latest/", None),
+    "CircuitPython": ("https://docs.circuitpython.org/en/latest/", None),
+}
+
+{% elif cookiecutter.requires_register in ["y", "yes"] -%}
+intersphinx_mapping = {
+    "python": ("https://docs.python.org/3", None),
+    "Register": ("https://docs.circuitpython.org/projects/register/en/latest/", None),
+    "CircuitPython": ("https://docs.circuitpython.org/en/latest/", None),
+}
+
+{% else -%}
+intersphinx_mapping = {
+    "python": ("https://docs.python.org/3", None),
+    "CircuitPython": ("https://docs.circuitpython.org/en/latest/", None),
+}
+
+{% endif -%}
 # Show the docstring from both the class and its __init__() method.
 autoclass_content = "both"
 


### PR DESCRIPTION
On a freshly baked library the sphinx docs fail with these warnings (treated as errors) about the api.rst file not containing a title
```
docs/index.rst:18: WARNING: toctree contains reference to document 'api' that doesn't have a title: no link will be generated [toc.no_title]
```

This change adds the title so that this error will not occur on new libraries. 