### PR TITLE
include sphinx config in the RTD.yaml

### DIFF
--- a/{{ cookiecutter.__dirname }}/{% if cookiecutter.sphinx_docs in ['y', 'yes'] %}.readthedocs.yaml{% endif %}
+++ b/{{ cookiecutter.__dirname }}/{% if cookiecutter.sphinx_docs in ['y', 'yes'] %}.readthedocs.yaml{% endif %}
@@ -8,6 +8,9 @@
 # Required
 version: 2
 
+sphinx:
+  configuration: docs/conf.py
+
 build:
   os: ubuntu-lts-latest
   tools:


### PR DESCRIPTION
This is the same fix as https://github.com/adafruit/Adafruit_CircuitPython_Bundle/pull/489

It addresses the fact that rtd.yaml files lacking sphinx configuration are being deprecated: https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/