### PR TITLE
add .gitattributes file

### DIFF
--- a/{{ cookiecutter.__dirname }}/.gitattributes
+++ b/{{ cookiecutter.__dirname }}/.gitattributes
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: 2024 Justin Myers
+#
+# SPDX-License-Identifier: Unlicense
+
+.py text eol=lf
+.rst text eol=lf
+.txt text eol=lf
+.yaml text eol=lf
+.toml text eol=lf
+.license text eol=lf
+.md text eol=lf


### PR DESCRIPTION
This file gets added to repos when they are converted over to ruff. I think it just got left out of cookie cutter by accident. 