### PR TITLE
Removed deprecated `ruff` rule `E999` from `ruff.toml`

### DIFF
--- a/{{ cookiecutter.__dirname }}/ruff.toml
+++ b/{{ cookiecutter.__dirname }}/ruff.toml
@@ -17,7 +17,6 @@ extend-select = [
   "PLC2401",  # non-ascii-name
   "PLC2801",  # unnecessary-dunder-call
   "PLC3002",  # unnecessary-direct-lambda-call
-  "E999",  # syntax-error
   "PLE0101",  # return-in-init
   "F706",  # return-outside-function
   "F704",  # yield-outside-function


### PR DESCRIPTION
Removed the check for rule [`E999 (sintax-error)`](https://docs.astral.sh/ruff/rules/syntax-error/), which has been deprecated, from `ruff.toml`. According to [the documentation](https://docs.astral.sh/ruff/rules/syntax-error/):

> Syntax errors will always be shown regardless of whether this rule is selected or not.

Using this rule produced an error when running the `ruff` `pre-commit` hook:

> ruff (legacy alias)......................................................Failed
> - hook id: ruff
> - exit code: 2
>
> ruff failed
>   Cause: Rule `E999` was removed and cannot be selected.

Resolves #249 