### PR TITLE
monkey patch rtd theme CSS glitch

### DIFF
--- a/{{ cookiecutter.__dirname }}/docs/_static/{% if cookiecutter.sphinx_docs in ['y', 'yes'] %}custom.css{% endif %}
+++ b/{{ cookiecutter.__dirname }}/docs/_static/{% if cookiecutter.sphinx_docs in ['y', 'yes'] %}custom.css{% endif %}
@@ -1,0 +1,8 @@
+/* SPDX-FileCopyrightText: 2025 Sam Blenny
+ * SPDX-License-Identifier: MIT
+ */
+
+/* Monkey patch the rtd theme to prevent horizontal stacking of short items
+ * see https://github.com/readthedocs/sphinx_rtd_theme/issues/1301
+ */
+.py.property{display: block !important;}

--- a/{{ cookiecutter.__dirname }}/docs/{% if cookiecutter.sphinx_docs in ['y', 'yes'] %}conf.py{% endif %}
+++ b/{{ cookiecutter.__dirname }}/docs/{% if cookiecutter.sphinx_docs in ['y', 'yes'] %}conf.py{% endif %}
@@ -140,6 +140,9 @@ html_theme = "sphinx_rtd_theme"
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ["_static"]
 
+# Include extra css to work around rtd theme glitches
+html_css_files = ["custom.css"]
+
 # The name of an image file (relative to this directory) to use as a favicon of
 # the docs.  This file should be a Windows icon file (.ico) being 16x16 or 32x32
 # pixels large.


### PR DESCRIPTION
This should hopefully prevent horizontal stacking of short items in the html documentation.

@FoamyGuy, this is for https://github.com/adafruit/Adafruit_CircuitPython_FruitJam/issues/17#issuecomment-3234312178, as requested.

I haven't tested whether this actually works. Merge with caution.