### PR TITLE
Use SPDX string for project.license in pyproject template

### DIFF
--- a/{{ cookiecutter.__dirname }}/pyproject.toml
+++ b/{{ cookiecutter.__dirname }}/pyproject.toml
@@ -56,13 +56,12 @@ keywords = [
 {% for kw_list_keyword in kw_list.default %}    "{{ kw_list_keyword }}",
 {% endfor -%}
 ]
-license = {text = "MIT"}
+license = "MIT"
 classifiers = [
     "Intended Audience :: Developers",
     "Topic :: Software Development :: Libraries",
     "Topic :: Software Development :: Embedded Systems",
     "Topic :: System :: Hardware",
-    "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
 ]
 dynamic = ["dependencies", "optional-dependencies"]


### PR DESCRIPTION
## Summary
Fixes the setuptools deprecation warning described in #254 by updating the generated `pyproject.toml` template:

- change `project.license` from TOML table to SPDX string (`"MIT"`)
- remove deprecated MIT license classifier from `project.classifiers`

This follows the packaging guidance referenced in the issue and avoids the upcoming setuptools breakage window for deprecated license metadata.

## Validation
- Template file updated: `{{ cookiecutter.__dirname }}/pyproject.toml`
- Attempted to run tests in a fresh venv; test collection currently fails in this environment due to an upstream dependency compatibility warning (`requests`/`urllib3` on Python 3.14), unrelated to this metadata-only change.
